### PR TITLE
ADD: User can confirm and reject requests against their spaces

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -59,6 +59,12 @@ class MakersBnB < Sinatra::Base
     erb :requests
   end
 
+  post '/requests/:req_id' do
+    status = params[:status] == 'Accept Booking' ? 'Confirmed' : 'Rejected'
+    Request.first(id: params[:req_id]).update(status: status)
+    redirect '/requests'
+  end
+
   get '/logout' do
     session.clear
     redirect '/sessions/new'

--- a/spec/features/confirm_booking_spec.rb
+++ b/spec/features/confirm_booking_spec.rb
@@ -11,10 +11,30 @@ feature 'Confirm booking' do
     expect(page).to have_content('2019-04-09')
     expect(page).to have_content('secondUser@gmail.com')
   end
-  # scenario 'I click confirm next to a request and see status changed to confirmed' do
-  #
-  # end
-  # scenario 'I click reject next to a request and see status changed to rejected' do
-  #
-  # end
+  scenario 'I click accept next to a request and see status changed to confirmed' do
+    user_sign_up('firstUser@gmail.com', '123')
+    add_space('My Place', 'Amazing flat', '50')
+    user_sign_up('secondUser@gmail.com', '123')
+    make_request('2019-04-09')
+    user_log_in('firstUser@gmail.com', '123')
+    visit '/requests'
+    click_button 'Accept Booking'
+    expect(page).to have_content('Confirmed')
+    expect(page).to have_content('My Place')
+    expect(page).to have_content('2019-04-09')
+    expect(page).to have_content('secondUser@gmail.com')
+  end
+  scenario 'I click reject next to a request and see status changed to rejected' do
+    user_sign_up('firstUser@gmail.com', '123')
+    add_space('My Place', 'Amazing flat', '50')
+    user_sign_up('secondUser@gmail.com', '123')
+    make_request('2019-04-09')
+    user_log_in('firstUser@gmail.com', '123')
+    visit '/requests'
+    click_button 'Reject Booking'
+    expect(page).to have_content('Rejected')
+    expect(page).to have_content('My Place')
+    expect(page).to have_content('2019-04-09')
+    expect(page).to have_content('secondUser@gmail.com')
+  end
 end

--- a/views/requests.erb
+++ b/views/requests.erb
@@ -21,7 +21,11 @@
     Space: <%= space.name %><br>
     Date: <%= request.date %><br>
     Status: <%= request.status %><br>
-    Requesting User: <%= user.email %>
+    Requesting User: <%= user.email %><br>
+    <form action='/requests/<%= request.id %>' method='POST'>
+      <input type="submit" name= 'status' value="Accept Booking">
+      <input type="submit" name= 'status' value="Reject Booking">
+    </form>
   </li>
 <% end %>
 </ul>


### PR DESCRIPTION
Confirm and Reject buttons added to each request against current user's spaces. These post to /spaces/:req_id route and update the status of the request in the request db appropriately